### PR TITLE
fix: 採点エージェントのスコア甘さ対策

### DIFF
--- a/packages/agent/dessin_coaching_agent/agent.py
+++ b/packages/agent/dessin_coaching_agent/agent.py
@@ -35,7 +35,7 @@ root_agent = Agent(
     name="dessin_coaching_agent",
     model=gemini_model,
     description="鉛筆デッサンを分析し、改善フィードバックを提供するコーチングエージェント",
-    instruction=get_dessin_analysis_system_prompt(),
+    instruction=get_dessin_analysis_system_prompt(rank_label=None),
     tools=[
         identify_motif,
         analyze_dessin_image,

--- a/packages/agent/dessin_coaching_agent/callbacks.py
+++ b/packages/agent/dessin_coaching_agent/callbacks.py
@@ -150,21 +150,9 @@ def _build_memory_fact(analysis: DessinAnalysis) -> str:
     improvements_text = ", ".join(analysis.improvements[:3]) if analysis.improvements else "なし"
     tags_text = ", ".join(analysis.tags) if analysis.tags else "なし"
 
-    # 成長情報
-    growth_score_text = (
-        f"{analysis.growth.score}/100"
-        if analysis.growth.score is not None
-        else "初回提出"
-    )
     growth_summary = analysis.growth.comparison_summary
 
     return f"""デッサン分析結果:
-- 総合スコア: {analysis.overall_score}/100
-- プロポーション: {analysis.proportion.score}/100
-- 陰影: {analysis.tone.score}/100
-- 質感: {analysis.texture.score}/100
-- 線の質: {analysis.line_quality.score}/100
-- 成長スコア: {growth_score_text}
 - 成長サマリー: {growth_summary}
 - 強み: {strengths_text}
 - 改善点: {improvements_text}


### PR DESCRIPTION
## 概要

採点エージェントのスコアが全体的に高止まりする問題に対策。

## 変更内容

### 1. スコア基準表の追加（prompts.py）
プロンプトにスコアの絶対基準を追加し、LLMが採点時に参照できるようにした。

| スコア範囲 | 評価 |
|-----------|------|
| 85-100 | 優秀 |
| 70-84 | 良い |
| 50-69 | 標準的 |
| 30-49 | 改善が必要 |
| 0-29 | 不十分 |

### 2. メモリからのスコアアンカリング除去
- **prompts.py**: メモリセクションからスコア数値をフィルタ除外（強み・改善点・タグのみ表示）
- **callbacks.py**: 保存するfactからスコア行を除外
- **tools.py**: `_calculate_growth_from_memories`から過去スコア取得・comparison_summary追記ロジックを削除し、初回判定のみに簡素化

## 原因分析

過去メモリに含まれるスコア数値（例: 76.25/100）がLLMのアンカリング効果により、新規採点を高止まりさせていた。一度甘い採点が始まると連鎖的にスコアが高い状態が続く構造になっていた。